### PR TITLE
ASM-1884- upgrade multiple libraries to address critical, high and medium vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>company-profile-search-consumer</artifactId>
-    <version>unversioned</version>
+    <version>latest</version>
     <name>company-profile-search consumer</name>
     <description>Company Profile Search Consumer</description>
 
@@ -20,14 +20,19 @@
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>3.5.6</spring.boot.version>
+        <spring.boot.version>3.5.9</spring.boot.version>
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
         <maven-build-helper-plugin.version>3.6.1</maven-build-helper-plugin.version>
         <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
+        <tomcat-embed-websocket.version>11.0.18</tomcat-embed-websocket.version>
+        <tomcat-embed-core.version>11.0.18</tomcat-embed-core.version>
+        <avro.version>1.12.1</avro.version>
+        <assertj-core.version>3.27.7</assertj-core.version>
+        <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Internal -->
-        <structured-logging.version>3.0.43</structured-logging.version>
-        <private-api-sdk-java.version>4.0.394</private-api-sdk-java.version>
+        <structured-logging.version>3.0.51</structured-logging.version>
+        <private-api-sdk-java.version>4.0.487</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.13</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.3</api-helper-java-library.version>
         <kafka-models.version>3.0.25</kafka-models.version>
@@ -83,7 +88,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.12.0</version>
+            <version>${avro.version}</version>
         </dependency>
 <!--        Transitive deps end here-->
 
@@ -154,6 +159,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Pinning version to address CVE-2025-61795 pulled by spring-boot-starter-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <version>${tomcat-embed-websocket.version}</version>
+        </dependency>
+        <!-- Pinning version to address CVE-2025-61795 pulled by spring-boot-starter-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat-embed-core.version}</version>
+        </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>ch-kafka</artifactId>
@@ -196,6 +213,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -272,6 +290,13 @@
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
             <version>1.9.7</version>
+        </dependency>
+        <!-- Pinning version to address CVE-2024-293714 pulled transitively by spring-kafka-test with no ch update yet-->
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>${jose4j.version}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
             <artifactId>jetty-ee</artifactId>
             <version>${jetty-ee.version}</version>
         </dependency>
+        <dependency>
+            <!--  Pinning version to address CVE-2026-1605 pulled in from latest jetty server version -->
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>${jetty-server.version}</version>
+        </dependency>
         <!--  Pinning version to address CVE-2025-68161 in spring-boot starter -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,16 @@
         <avro.version>1.12.1</avro.version>
         <assertj-core.version>3.27.7</assertj-core.version>
         <jose4j.version>0.9.6</jose4j.version>
+        <jetty-ee.version>12.0.33</jetty-ee.version>
+        <jetty-server.version>12.1.6</jetty-server.version>
+        <log4j.version>2.25.3</log4j.version>
 
         <!-- Internal -->
         <structured-logging.version>3.0.51</structured-logging.version>
-        <private-api-sdk-java.version>4.0.487</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.489</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.13</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.3</api-helper-java-library.version>
-        <kafka-models.version>3.0.25</kafka-models.version>
+        <kafka-models.version>3.0.29</kafka-models.version>
         <ch-kafka.version>3.0.6</ch-kafka.version>
 
         <!-- tests -->
@@ -89,6 +92,42 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
+        </dependency>
+        <!-- Pinning version to address CVE-2024-293714 pulled transitively by spring-kafka-test-->
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>${jose4j.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- Pinning version to address CVE-2026-1605 pulled transitively from latest kafka model version-->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty-server.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-ee</artifactId>
+            <version>${jetty-ee.version}</version>
+        </dependency>
+        <!--  Pinning version to address CVE-2025-68161 in spring-boot starter -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <!-- Pinning version to address CVE-2025-61795 pulled by spring-boot-starter-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <version>${tomcat-embed-websocket.version}</version>
+        </dependency>
+        <!-- Pinning version to address CVE-2025-61795 pulled by spring-boot-starter-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat-embed-core.version}</version>
         </dependency>
 <!--        Transitive deps end here-->
 
@@ -158,18 +197,6 @@
                     <artifactId>jetty-webapp</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <!-- Pinning version to address CVE-2025-61795 pulled by spring-boot-starter-->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${tomcat-embed-websocket.version}</version>
-        </dependency>
-        <!-- Pinning version to address CVE-2025-61795 pulled by spring-boot-starter-->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat-embed-core.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
@@ -290,13 +317,6 @@
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
             <version>1.9.7</version>
-        </dependency>
-        <!-- Pinning version to address CVE-2024-293714 pulled transitively by spring-kafka-test with no ch update yet-->
-        <dependency>
-            <groupId>org.bitbucket.b_c</groupId>
-            <artifactId>jose4j</artifactId>
-            <version>${jose4j.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>company-profile-search-consumer</artifactId>
-    <version>latest</version>
+    <version>unversioned</version>
     <name>company-profile-search consumer</name>
     <description>Company Profile Search Consumer</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,13 @@
             <artifactId>jetty-ee</artifactId>
             <version>${jetty-ee.version}</version>
         </dependency>
+        <!--  Pinning version to address CVE-2026-1605 pulled in from latest jetty server version -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${jetty-server.version}</version>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <!--  Pinning version to address CVE-2026-1605 pulled in from latest jetty server version -->
             <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,12 +106,46 @@
             <artifactId>jetty-server</artifactId>
             <version>${jetty-server.version}</version>
         </dependency>
+        <!--  Pinning version to address CVE-2026-1605 pulled in from kafka-models and jetty version -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-ee</artifactId>
             <version>${jetty-ee.version}</version>
         </dependency>
-        <!--  Pinning version to address CVE-2026-1605 pulled in from latest jetty server version -->
+        <!--  Pinning version to address CVE-2026-1605 pulled in from kafka-models and jetty version -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${jetty-server.version}</version>
+        </dependency>
+        <!--  Pinning version to address CVE-2026-1605 pulled in from kafka-models and jetty version -->
+        <dependency>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-webapp</artifactId>
+            <version>${jetty-server.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <!--  Pinning version to address CVE-2026-1605 pulled in from kafka-models and jetty version -->
+        <dependency>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-servlet</artifactId>
+            <version>${jetty-server.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <!--  Pinning version to address CVE-2026-1605 pulled in from kafka-models and jetty version -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-session</artifactId>
+            <version>${jetty-server.version}</version>
+        </dependency>
+        <!--  Pinning version to address CVE-2026-1605 pulled in from kafka-models and jetty version -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-xml</artifactId>
+            <version>${jetty-server.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <!--  Pinning version to address CVE-2026-1605 pulled in from kafka-models and jetty version -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
@@ -123,6 +157,13 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
             <version>${jetty-server.version}</version>
+        </dependency>
+        <!--  Pinning version to address CVE-2026-1605 pulled in from latest jetty server version -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+            <version>${jetty-server.version}</version>
+            <scope>compile</scope>
         </dependency>
         <!--  Pinning version to address CVE-2025-68161 in spring-boot starter -->
         <dependency>


### PR DESCRIPTION
Upgrade multiple libraries to address critical, high and medium vulnerabilities

Including
```
- Spring-boot
- tomcat-embed-websocket
- tomcat-embed-core
- avro
- assertjjcore
- jose4j
- log4j
- structured-logging
- kafka-models
- private-api-sdk-java
```

Pinning various `jetty` versions all of which lacked updates to safe versions through their parent dependencies